### PR TITLE
Add GitHub Pages deployment guide

### DIFF
--- a/静的サイト無料デプロイ手順.md
+++ b/静的サイト無料デプロイ手順.md
@@ -1,0 +1,82 @@
+# 静的なWebページを無料でデプロイする手順書（GitHub Pages編）
+
+## 1. 目的と概要
+- GitHub Pages を使って、HTML/CSS/JavaScript などで構成された静的サイトを無料で公開する。
+- GitHub アカウントを利用し、バージョン管理とホスティングを同時に行う。
+
+## 2. 前提条件
+1. GitHub アカウントを持っている。
+2. Git とターミナル（もしくは GitHub Desktop 等の GUI クライアント）を利用できる。
+3. 公開したい静的ファイル（`index.html` など）が手元にある。
+
+> **Tip:** GitHub Pages は 1 アカウントにつき 1 つのユーザーページ（`https://<ユーザー名>.github.io`）と、複数のプロジェクトページを無料で利用できます。
+
+## 3. 新規リポジトリの作成
+1. ブラウザで GitHub にサインインし、右上の **`+`** から **New repository** を選択。
+2. Repository name にサイト名を入力（例: `my-static-site`）。
+3. Public を選択し、**Create repository** をクリック。
+4. `README` や `.gitignore` は任意。必要に応じて追加してください。
+
+## 4. ローカルにファイルを準備
+```bash
+# 任意の作業ディレクトリで
+mkdir my-static-site
+cd my-static-site
+
+# 初期化とリモート登録
+git init
+git remote add origin https://github.com/<ユーザー名>/my-static-site.git
+```
+
+1. 公開したい `index.html` や `style.css` などを `my-static-site` フォルダに配置。
+2. コミットして GitHub にプッシュ：
+   ```bash
+   git add .
+   git commit -m "Initial commit"
+   git branch -M main
+   git push -u origin main
+   ```
+
+> **ブラウザ上だけで完結したい場合**：リポジトリ画面で **Add file → Upload files** を選択し、ファイルをドラッグ＆ドロップして直接アップロードできます。
+
+## 5. GitHub Pages の有効化
+1. リポジトリの **Settings** タブを開く。
+2. 左メニューで **Pages** を選択。
+3. **Build and deployment** セクションの **Source** で `Deploy from a branch` を選択。
+4. Branch で `main`、フォルダで `/ (root)` を指定し、**Save** をクリック。
+5. 数十秒〜数分でデプロイが完了し、ページ上部に公開 URL (`https://<ユーザー名>.github.io/my-static-site/`) が表示される。
+
+## 6. 動作確認
+1. 表示された URL にアクセスし、ページが想定どおり表示されるか確認。
+2. レイアウト崩れやリンク切れがないか確認する。
+3. 更新が反映されない場合は、ブラウザのキャッシュを削除するか、`Ctrl+Shift+R`（ハードリロード）を試す。
+
+## 7. 変更の反映
+1. ファイルを更新したら以下を実行：
+   ```bash
+   git add .
+   git commit -m "Update site contents"
+   git push
+   ```
+2. 数十秒待つと GitHub Pages が自動で再デプロイし、最新の内容が公開される。
+
+## 8. 任意の追加設定
+- **カスタムドメイン**：Pages 設定画面の **Custom domain** に独自ドメインを設定し、DNS で `CNAME` レコードを `your-username.github.io` に向ける。
+- **HTTPS**：Pages 設定で "Enforce HTTPS" にチェックを入れる。
+- **ビルドツールを使う場合**（例: React/Vite）：ビルド成果物（`dist` フォルダなど）を `main` ブランチの公開対象フォルダに配置するよう、GitHub Actions やカスタムブランチを利用する。
+
+## 9. トラブルシューティング
+| 症状 | 対処方法 |
+| --- | --- |
+| 404 エラーが表示される | デプロイ完了まで数分かかる場合があるため待機。`index.html` がルートに存在するか確認。 |
+| CSS/JS が反映されない | 相対パスを確認。`/` から始まる絶対パスは GitHub Pages のサブパスで動作しないため、相対パスか `./` を利用。 |
+| 独自ドメインで HTTPS 化できない | DNS 設定が正しいか、証明書の発行に最大 24 時間かかることを確認。 |
+
+---
+
+## 10. 代替サービス（必要に応じて）
+- **Netlify**：GitHub リポジトリと連携するだけで自動デプロイ。フォーム機能なども無料枠あり。
+- **Vercel**：Next.js などのフレームワークと相性が良く、プルリクごとのプレビュー URL を自動生成。
+- **Cloudflare Pages**：ビルドコマンドを指定して Jamstack サイトをデプロイ。CDN 配信が可能。
+
+どのサービスも基本的な操作は「リポジトリを連携 → ビルド設定 → 自動デプロイ」で共通しているため、用途に応じて選択してください。


### PR DESCRIPTION
## Summary
- add a Japanese markdown guide for deploying static websites for free using GitHub Pages
- include prerequisites, setup steps, troubleshooting tips, and alternative free hosting services

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cae4c038b0832ab5403f653ef5e467